### PR TITLE
empty mediatype and subtype processing

### DIFF
--- a/src/django_accept_header/exceptions.py
+++ b/src/django_accept_header/exceptions.py
@@ -1,0 +1,10 @@
+class ParsingError(Exception):
+    pass
+
+
+class MediaTypeValueError(ParsingError):
+    pass
+
+
+class SubtypeValueError(ParsingError):
+    pass

--- a/src/django_accept_header/header.py
+++ b/src/django_accept_header/header.py
@@ -19,11 +19,13 @@ import re
 
 from collections import OrderedDict as kv
 
+from . import exceptions
+
 
 class MediaType(object):
 
     def __init__(self, media_type, q=None, params=None):
-        (self._mediatype, self._subtype) = media_type.split('/')
+        self.mediatype, _, self.subtype = media_type.partition('/')
         self._quality = q or 1.0
         self._params = params or {}
 
@@ -32,7 +34,7 @@ class MediaType(object):
 
     def __str__(self):
         if len(self.params) > 0:
-            p = '; '.join(['{key}={value}'.format(key=k, value=v) for k, v in self.params.items()])
+            p = '; '.join('{key}={value}'.format(key=k, value=v) for k, v in self.params.items())
             return '%s; q=%s; %s' % (self.mimetype, self.q, p)
         else:
             return '%s; q=%s' % (self.mimetype, self.q)
@@ -75,9 +77,21 @@ class MediaType(object):
     def mediatype(self):
         return self._mediatype
 
+    @mediatype.setter
+    def mediatype(self, value):
+        if not value:
+            raise exceptions.MediaTypeValueError(value)
+        self._mediatype = value
+
     @property
     def subtype(self):
         return self._subtype
+
+    @subtype.setter
+    def subtype(self, value):
+        if not value:
+            raise exceptions.SubtypeValueError(value)
+        self._subtype = value
 
     @property
     def quality(self):

--- a/src/django_accept_header/middleware.py
+++ b/src/django_accept_header/middleware.py
@@ -15,13 +15,18 @@
 
 from __future__ import absolute_import
 
+from django import http
+
+from .exceptions import ParsingError
 from .header import parse
 
 
 class AcceptMiddleware(object):
 
     def process_request(self, request):
-        acc = parse(request.META.get('HTTP_ACCEPT'))
+        try:
+            acc = parse(request.META.get('HTTP_ACCEPT'))
+        except ParsingError:
+            return http.HttpResponseBadRequest()
         setattr(request, 'accepted_types', acc)
-        request.accepts = lambda mt: any([ma.matches(mt) for ma in acc])
-        return None
+        request.accepts = lambda mt: any(ma.matches(mt) for ma in acc)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,6 +19,7 @@
 import unittest
 
 from django_accept_header.header import parse, MediaType
+from django_accept_header.exceptions import MediaTypeValueError, SubtypeValueError
 
 
 class ParserTestCase(unittest.TestCase):
@@ -240,6 +241,18 @@ class MediaTypeTestCase(unittest.TestCase):
             MediaType('application/*').subtype,
             '*'
         )
+
+    def test_invalid_media_types(self):
+        with self.assertRaises(MediaTypeValueError):
+            MediaType('/json')
+        with self.assertRaises(MediaTypeValueError):
+            MediaType('/')
+
+    def test_invalid_subtypes(self):
+        with self.assertRaises(SubtypeValueError):
+            MediaType('application/')
+        with self.assertRaises(SubtypeValueError):
+            MediaType('application')
 
     def test_all_subtypes(self):
         self.assertFalse(MediaType('application/json').all_subtypes)


### PR DESCRIPTION
Hello, i notice that request w/o subtype like
`curl -H "Accept:application"  'http://mydjango.site/'` causes responses with 500 status codes.
I'm not sure which response code is correct for that occurrence, but lurk for a while and I think 400 is good choice.
https://github.com/for-GET/http-decision-diagram
