### PR TITLE
Add routing based on best_match

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 =======
 
 * Michael Fladischer - https://www.fladi.at/
+* Craig Blaszczyk - masterjakul@gmail.com

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,17 @@ The ordered list of accepted mimetypes can also be used::
         for media_type in request.accepted_types:
             # do something
 
+You can also adjust the view's response based on the accept which response type the client can render well::
+
+    def some_view(request):
+        if request.best_match(['text/html', 'text/yaml']) == 'text/html':
+            # render HTML page
+        else:
+            # render YAML page
+
 See the full documentation for how to use the media types please see the full documentation.
+
+
 
 Documentation
 =============

--- a/src/django_accept_header/header.py
+++ b/src/django_accept_header/header.py
@@ -163,7 +163,8 @@ def parse(value):
 def best_match(desired, accepted, default=None):
     """Returns the best match from a list of possible matches based
     on the quality of the client.  If two items have the same quality,
-    the one is returned that comes first.
+    the one is returned that comes first. This is based on a similar function
+    in Werkzeug.
 
     :param desired: a list of strings of mimetypes to check for
     :param accepted: a list of accepted :class MediaType:

--- a/src/django_accept_header/header.py
+++ b/src/django_accept_header/header.py
@@ -158,3 +158,25 @@ def parse(value):
         )
     results.sort()
     return results
+
+
+def best_match(desired, accepted, default=None):
+    """Returns the best match from a list of possible matches based
+    on the quality of the client.  If two items have the same quality,
+    the one is returned that comes first.
+
+    :param desired: a list of strings of mimetypes to check for
+    :param accepted: a list of accepted :class MediaType:
+    :param default: the value that is returned if none match
+    """
+    best_quality = -1
+    result = default
+    for mimetype in desired:
+        for client_item in accepted:
+            if client_item.quality <= best_quality:
+                break
+            if client_item.matches(mimetype) \
+               and client_item.quality > 0:
+                best_quality = client_item.quality
+                result = mimetype
+    return result

--- a/src/django_accept_header/middleware.py
+++ b/src/django_accept_header/middleware.py
@@ -15,10 +15,12 @@
 
 from __future__ import absolute_import
 
+from functools import partial
+
 from django import http
 
 from .exceptions import ParsingError
-from .header import parse
+from .header import parse, best_match
 
 
 class AcceptMiddleware(object):
@@ -30,3 +32,4 @@ class AcceptMiddleware(object):
             return http.HttpResponseBadRequest()
         setattr(request, 'accepted_types', acc)
         request.accepts = lambda mt: any(ma.matches(mt) for ma in acc)
+        request.best_match = partial(best_match, accepted=acc)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -78,3 +78,31 @@ class AcceptMiddlewareTest(unittest.TestCase):
         self.assertTrue(request.accepts('application/xhtml+xml'))
         self.assertTrue(request.accepts('application/xml'))
         self.assertFalse(request.accepts('image/png'))
+
+    def test_process_request_best_match(self):
+        request = Mock(
+            META={
+                'HTTP_ACCEPT': 'text/html,application/xhtml+xml;q=0.9,application/xml;q=0.9'
+            }
+        )
+        self.am.process_request(request)
+        self.assertEqual(
+            request.best_match(['application/xml', 'text/html', 'image/png']),
+            'text/html'
+        )
+        self.assertEqual(
+            request.best_match(['application/xml', 'application/xhtml+xml']),
+            'application/xml'
+        )
+        self.assertIsNone(request.best_match(['image/png']))
+        self.assertEqual(
+            request.best_match(['image/png'], default='text/plain'),
+            'text/plain'
+        )
+
+        request2 = Mock(META={'HTTP_ACCEPT': 'text/html,*/*;q=0.8'})
+        self.am.process_request(request2)
+        self.assertEqual(
+            request2.best_match(['image/png'], default='text/plain'),
+            'image/png'
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from django_accept_header.header import parse, MediaType
+from django_accept_header.header import parse, MediaType, best_match
 from django_accept_header.exceptions import MediaTypeValueError, SubtypeValueError
 
 
@@ -295,3 +295,40 @@ class MediaTypeTestCase(unittest.TestCase):
     def test_getitem_param_none(self):
         m = MediaType('application/json')
         self.assertIsNone(m['test'])
+
+
+class BestMatchTestCase(unittest.TestCase):
+
+    def test_best_match(self):
+        accepted = [
+            MediaType('text/plain', q=0.9),
+            MediaType('text/html', q=0.1),
+        ]
+        desired = ['text/html', 'text/plain']
+        self.assertEqual(best_match(desired, accepted), 'text/plain')
+
+    def test_use_first_in_desires_list_when_quality_is_equal(self):
+        accepted = [
+            MediaType('text/plain', q=0.9),
+            MediaType('text/html', q=0.9),
+        ]
+        desired = ['text/html', 'text/plain']
+        self.assertEqual(best_match(desired, accepted), 'text/html')
+
+    def test_use_default(self):
+        accepted = [
+            MediaType('text/plain', q=0.9),
+            MediaType('text/html', q=0.9),
+        ]
+        desired = ['image/png']
+        self.assertEqual(
+            best_match(desired, accepted, 'text/plain'), 'text/plain'
+        )
+
+    def test_return_none_if_no_match(self):
+        accepted = [
+            MediaType('text/plain', q=0.9),
+            MediaType('text/html', q=0.9),
+        ]
+        desired = ['image/png']
+        self.assertIsNone(best_match(desired, accepted))


### PR DESCRIPTION
This replicates a function present in Werkzeug, which can be used to help render files differently based on the client's quality score for each accept header. 

I use it to render a yaml file in `<pre></pre>` tags when being viewed in a browser, but not when being requested from the command line.